### PR TITLE
versionist: Change repository type

### DIFF
--- a/repo.yml
+++ b/repo.yml
@@ -1,3 +1,3 @@
 ---
-type: 'yocto-based OS image'
+type: 'yocto layer'
 reviewers: 1


### PR DESCRIPTION
As the project does not have the structure of a device type repository
it fits better as a yocto layer.

Change-type: patch
Signed-off-by: Alex Gonzalez <alexg@balena.io>